### PR TITLE
Support returning an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,5 @@ module.exports = function getProp(obj, path) {
 
 	path = path.split('.');
 
-	return getProp(obj[path.shift()], path.join('.'));
+	return getProp(obj[path.shift()], path.length && path.join('.'));
 };

--- a/test.js
+++ b/test.js
@@ -3,8 +3,9 @@ var test = require('ava');
 var dotProp = require('./');
 
 test(function (t) {
-	var f1 = {foo: 1};
+	var f1 = {foo: {bar: 1}};
 	t.assert(dotProp(f1) === f1);
+	t.assert(dotProp(f1, 'foo') === f1.foo);
 	t.assert(dotProp({foo: 1}, 'foo') === 1);
 	t.assert(dotProp({foo: null}, 'foo') === null);
 	t.assert(dotProp({foo: undefined}, 'foo') === undefined);


### PR DESCRIPTION
Currently, looking up an object at `path` will return `undefined`. The code recurses one time too many because `[].join('.')` is still a string. This fixes that.

``` js
dotProp({foo: {bar: 1}}, 'foo'); // undefined, should be {bar: 1}
```