### PR TITLE
Rewrite this module

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,38 @@ function isObject(x) {
 	return typeof x === 'object' && x !== null;
 }
 
-module.exports = function getProp(obj, path) {
+module.exports.get = function (obj, path) {
 	if (!isObject(obj) || typeof path !== 'string') {
 		return obj;
 	}
 
-	path = path.split('.');
+	var pathArr = path.split('.');
+	pathArr.some(function (path, index) {
+		obj = obj[path];
 
-	return getProp(obj[path.shift()], path.length && path.join('.'));
+		if (obj === undefined) {
+			return true;
+		}
+	});
+
+	return obj;
+};
+
+module.exports.set = function (obj, path, value) {
+	if (!isObject(obj) || typeof path !== 'string') {
+		return;
+	}
+
+	var pathArr = path.split('.');
+	pathArr.forEach(function (path, index) {
+		if (!isObject(obj[path])) {
+			obj[path] = {};
+		}
+
+		if (index === pathArr.length - 1) {
+			obj[path] = value;
+		}
+
+		obj = obj[path];
+	});
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dot-prop",
   "version": "1.0.1",
-  "description": "Get a property from a nested object using a dot path",
+  "description": "Get or set a property from a nested object using a dot path",
   "license": "MIT",
   "repository": "sindresorhus/dot-prop",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # dot-prop [![Build Status](https://travis-ci.org/sindresorhus/dot-prop.svg?branch=master)](https://travis-ci.org/sindresorhus/dot-prop)
 
-> Get a property from a nested object using a dot path
+> Get or set a property from a nested object using a dot path
 
 
 ## Install
@@ -15,11 +15,22 @@ $ npm install --save dot-prop
 ```js
 var dotProp = require('dot-prop');
 
-dotProp({foo: {bar: 'unicorn'}}, 'foo.bar');
+// getter
+dotProp.get({foo: {bar: 'unicorn'}}, 'foo.bar');
 //=> 'unicorn'
 
-dotProp({foo: {bar: 'a'}}, 'foo.notDefined.deep');
+dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep');
 //=> undefined
+
+// setter
+var obj = {foo: {bar: 'a'}};
+dotProp.set(obj, 'foo.bar', 'b');
+console.log(obj);
+//=> {foo: {bar: 'b'}}
+
+dotProp.set(obj, 'foo.baz', 'x');
+console.log(obj);
+//=> {foo: {bar: 'b', baz: 'x'}}
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -2,16 +2,54 @@
 var test = require('ava');
 var dotProp = require('./');
 
-test(function (t) {
+test(function getter (t) {
 	var f1 = {foo: {bar: 1}};
-	t.assert(dotProp(f1) === f1);
-	t.assert(dotProp(f1, 'foo') === f1.foo);
-	t.assert(dotProp({foo: 1}, 'foo') === 1);
-	t.assert(dotProp({foo: null}, 'foo') === null);
-	t.assert(dotProp({foo: undefined}, 'foo') === undefined);
-	t.assert(dotProp({foo: {bar: true}}, 'foo.bar') === true);
-	t.assert(dotProp({foo: {bar: {baz: true}}}, 'foo.bar.baz') === true);
-	t.assert(dotProp({foo: {bar: {baz: null}}}, 'foo.bar.baz') === null);
-	t.assert(dotProp({foo: {bar: 'a'}}, 'foo.fake.fake2') === undefined);
+	t.assert(dotProp.get(f1) === f1);
+	t.assert(dotProp.get(f1, 'foo') === f1.foo);
+	t.assert(dotProp.get({foo: 1}, 'foo') === 1);
+	t.assert(dotProp.get({foo: null}, 'foo') === null);
+	t.assert(dotProp.get({foo: undefined}, 'foo') === undefined);
+	t.assert(dotProp.get({foo: {bar: true}}, 'foo.bar') === true);
+	t.assert(dotProp.get({foo: {bar: {baz: true}}}, 'foo.bar.baz') === true);
+	t.assert(dotProp.get({foo: {bar: {baz: null}}}, 'foo.bar.baz') === null);
+	t.assert(dotProp.get({foo: {bar: 'a'}}, 'foo.fake.fake2') === undefined);
+	t.end();
+});
+
+test(function setter (t) {
+	var f1 = {};
+
+	function func() {
+	  return 'test';
+	}
+
+	dotProp.set(f1, 'foo', 2);
+	t.assert(f1.foo === 2);
+
+	f1 = {foo: {bar: 1}};
+	dotProp.set(f1, 'foo.bar', 2);
+	t.assert(f1.foo.bar === 2);
+
+	dotProp.set(f1, 'foo.bar.baz', 3);
+	t.assert(f1.foo.bar.baz === 3);
+
+	dotProp.set(f1, 'foo.bar', 'test');
+	t.assert(f1.foo.bar === 'test');
+
+	dotProp.set(f1, 'foo.bar', null);
+	t.assert(f1.foo.bar === null);
+
+	dotProp.set(f1, 'foo.bar', false);
+	t.assert(f1.foo.bar === false);
+
+	dotProp.set(f1, 'foo.bar', undefined);
+	t.assert(f1.foo.bar === undefined);
+
+	dotProp.set(f1, 'foo.fake.fake2', 'fake');
+	t.assert(f1.foo.fake.fake2 === 'fake');
+
+	dotProp.set(f1, 'foo.function', func);
+	t.assert(f1.foo.function === func);
+
 	t.end();
 });


### PR DESCRIPTION
Setter. While it is possible to impliment setter using recursion, it would not work with getter (`t.assert(dotProp(f1, 'foo', 2) === 2);` would fail).
It avoids recursion. I personally find recursive functions are hard to follow.
`dotProp({foo: {bar: a}}, foo.fake.fake2)` should throw a TypeError instead of returning `undefined`.
Use lodash to avoid reinventing the wheel.