### PR TITLE
Accept array as path to enable access to props with dots

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,16 @@ function isObject(x) {
 }
 
 module.exports.get = function (obj, path) {
-	if (!isObject(obj) || typeof path !== 'string') {
+	if (!isObject(obj) || (typeof path !== 'string' && !Array.isArray(path))) {
 		return obj;
 	}
 
-	var pathArr = path.split('.');
+	var pathArr = path;
+
+	if (typeof path === 'string') {
+		pathArr = path.split('.');
+	}
+
 	pathArr.some(function (path, index) {
 		obj = obj[path];
 
@@ -22,11 +27,16 @@ module.exports.get = function (obj, path) {
 };
 
 module.exports.set = function (obj, path, value) {
-	if (!isObject(obj) || typeof path !== 'string') {
+	if (!isObject(obj) || (typeof path !== 'string' && !Array.isArray(path))) {
 		return;
 	}
 
-	var pathArr = path.split('.');
+	var pathArr = path;
+
+	if (typeof path === 'string') {
+		pathArr = path.split('.');
+	}
+
 	pathArr.forEach(function (path, index) {
 		if (!isObject(obj[path])) {
 			obj[path] = {};

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ dotProp.get({foo: {bar: 'unicorn'}}, 'foo.bar');
 dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep');
 //=> undefined
 
+dotProp.get({'foo.bar': {baz: 'a'}}, ['foo.bar', 'baz']);
+//=> 'a'
+
 // setter
 var obj = {foo: {bar: 'a'}};
 dotProp.set(obj, 'foo.bar', 'b');
@@ -31,6 +34,10 @@ console.log(obj);
 dotProp.set(obj, 'foo.baz', 'x');
 console.log(obj);
 //=> {foo: {bar: 'b', baz: 'x'}}
+
+dotProp.set(obj, ['foo.bar', 'baz'], 'x');
+console.log(obj);
+//=> {'foo.bar': {baz: 'x'}}
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test(function getter (t) {
 	t.assert(dotProp.get({foo: {bar: {baz: true}}}, 'foo.bar.baz') === true);
 	t.assert(dotProp.get({foo: {bar: {baz: null}}}, 'foo.bar.baz') === null);
 	t.assert(dotProp.get({foo: {bar: 'a'}}, 'foo.fake.fake2') === undefined);
+	t.assert(dotProp.get({'foo.bar': true}, ['foo.bar']) === true);
 	t.end();
 });
 
@@ -50,6 +51,9 @@ test(function setter (t) {
 
 	dotProp.set(f1, 'foo.function', func);
 	t.assert(f1.foo.function === func);
+
+	dotProp.set(f1, ['foo.bar'], func);
+	t.assert(f1['foo.bar'] === func);
 
 	t.end();
 });


### PR DESCRIPTION
I have try'd to implement `\\.` escaping, but after `path.match(/([^\\\][^.]|\\.)+/g)` to split path I decided to stop (because after this you will need to replace `\.` with `.` in every path part).

