### PR TITLE
Accept escaped dots in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,20 @@ module.exports.get = function (obj, path) {
 	}
 
 	var pathArr = path.split('.');
-	pathArr.some(function (path, index) {
-		obj = obj[path];
+	for (var index = 0; index < pathArr.length; index++) {
+		var p = pathArr[index];
+		while (p[p.length - 1] === '\\') {
+			p = p.slice(0, -1) + '.';
+			index ++;
+			p += pathArr[index];
+		}
+
+		obj = obj[p];
 
 		if (obj === undefined) {
-			return true;
+			break;
 		}
-	});
+	}
 
 	return obj;
 };
@@ -27,15 +34,22 @@ module.exports.set = function (obj, path, value) {
 	}
 
 	var pathArr = path.split('.');
-	pathArr.forEach(function (path, index) {
-		if (!isObjOrFn(obj[path])) {
-			obj[path] = {};
+	for (var index = 0; index < pathArr.length; index++) {
+		var p = pathArr[index];
+		while (p[p.length - 1] === '\\') {
+			p = p.slice(0, -1) + '.';
+			index ++;
+			p += pathArr[index];
+		}
+
+		if (!isObjOrFn(obj[p])) {
+			obj[p] = {};
 		}
 
 		if (index === pathArr.length - 1) {
-			obj[path] = value;
+			obj[p] = value;
 		}
 
-		obj = obj[path];
-	});
+		obj = obj[p];
+	}
 };

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ dotProp.get({foo: {bar: 'unicorn'}}, 'foo.bar');
 dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep');
 //=> undefined
 
+dotProp.get({foo: {'dot.dot': '.'}}, 'foo.dot\\.dot');
+//=> '.'
+
 // setter
 var obj = {foo: {bar: 'a'}};
 dotProp.set(obj, 'foo.bar', 'b');
@@ -31,8 +34,11 @@ console.log(obj);
 dotProp.set(obj, 'foo.baz', 'x');
 console.log(obj);
 //=> {foo: {bar: 'b', baz: 'x'}}
-```
 
+dotProp.set(obj, 'foo.dot\\.dot', '.');
+console.log(obj);
+//=> {foo: {bar: 'b', baz: 'x', 'dot.dot': '.'}}
+```
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -19,6 +19,9 @@ test(function getter(t) {
 	t.assert(dotProp.get(fn), fn)
 	t.assert(dotProp.get(fn, 'foo') === fn.foo)
 	t.assert(dotProp.get(fn, 'foo.bar') === 1);
+
+	t.assert(dotProp.get({'foo.baz': {bar: true}}, 'foo\\.baz.bar') === true);
+	t.assert(dotProp.get({'fo.ob.az': {bar: true}}, 'fo\\.ob\\.az.bar') === true);
 	t.end();
 });
 
@@ -64,6 +67,12 @@ test(function setter(t) {
 	f1.fn = fn;
 	dotProp.set(f1, 'fn.bar.baz', 2);
 	t.assert(f1.fn.bar.baz, 2);
+
+	dotProp.set(f1, 'foo\\.bar.baz', true);
+	t.assert(f1['foo.bar'].baz === true);
+
+	dotProp.set(f1, 'fo\\.ob\\.ar.baz', true);
+	t.assert(f1['fo.ob.ar'].baz === true);
 
 	t.end();
 });


### PR DESCRIPTION
Alternative of #7 

Allow escaped dots (`\\.`) in paths.