### PR TITLE
ignore non-enumerable properties - fixes #23

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ module.exports.get = function (obj, path) {
 	var pathArr = getPathSegments(path);
 
 	for (var i = 0; i < pathArr.length; i++) {
+		var descriptor = Object.getOwnPropertyDescriptor(obj, pathArr[i]) || Object.getOwnPropertyDescriptor(Object.prototype, pathArr[i]);
+		if (descriptor && !descriptor.enumerable) {
+			return;
+		}
+
 		obj = obj[pathArr[i]];
 
 		if (obj === undefined) {

--- a/test.js
+++ b/test.js
@@ -13,6 +13,11 @@ test('get', t => {
 	t.is(m.get({foo: {bar: {baz: null}}}, 'foo.bar.baz'), null);
 	t.is(m.get({foo: {bar: 'a'}}, 'foo.fake.fake2'), undefined);
 
+	const f2 = {};
+	Object.defineProperty(f2, 'foo', {value: 'bar', enumerable: false});
+	t.is(m.get(f2, 'foo'), undefined);
+	t.is(m.get({}, 'hasOwnProperty'), undefined);
+
 	function fn() {}
 	fn.foo = {bar: 1};
 	t.is(m.get(fn), fn);


### PR DESCRIPTION
As far as I could make up from the conversation in #23, this might solve the issue.

If the property that is trying to be accessed, is non-enumerable, it will return `undefined`.