### PR TITLE
add .npmignore to add meteor support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.editorconfig
+.gitattributes
+.gitignore
+.travis.yml
+bench.js
+test.js


### PR DESCRIPTION
Specifically the `test.js` file breaks support for meteor. It seems that meteor tries to bundle everything of a npm module and complains about usage of `import` statements in this file