### PR TITLE
ability to pass an array as a second parameter

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -45,6 +45,49 @@ bench('get', () => {
 	m.get({'fo.ob.az': {bar: true}}, 'fo\\.ob\\.az.bar');
 });
 
+bench('get (array)', () => {
+	const f1 = {foo: {bar: 1}};
+	m.get(f1);
+	f1[''] = 'foo';
+	m.get(f1, ['']);
+	m.get(f1, ['foo']);
+	m.get({foo: 1}, ['foo']);
+	m.get({foo: null}, ['foo']);
+	m.get({foo: undefined}, ['foo']);
+	m.get({foo: {bar: true}}, ['foo', 'bar']);
+	m.get({foo: {bar: {baz: true}}}, ['foo', 'bar', 'baz']);
+	m.get({foo: {bar: {baz: null}}}, ['foo', 'bar', 'baz']);
+	m.get({foo: {bar: 'a'}}, ['foo', 'fake']);
+	m.get({foo: {bar: 'a'}}, ['foo', 'fake', 'fake2']);
+	m.get({'\\': true}, ['\\']);
+	m.get({'\\foo': true}, ['\\foo']);
+	m.get({'bar\\': true}, ['bar\\']);
+	m.get({'foo\\bar': true}, ['foo\\bar']);
+	m.get({'\\.foo': true}, ['\\.foo']);
+	m.get({'bar\\.': true}, ['bar\\.']);
+	m.get({'foo\\.bar': true}, ['foo\\.bar']);
+
+	const f2 = {};
+	Object.defineProperty(f2, 'foo', {
+		value: 'bar',
+		enumerable: false
+	});
+	m.get(f2, ['foo']);
+	m.get({}, ['hasOwnProperty']);
+
+	function fn() {}
+	fn.foo = {bar: 1};
+	m.get(fn);
+	m.get(fn, ['foo']);
+	m.get(fn, ['foo', 'bar']);
+
+	const f3 = {foo: null};
+	m.get(f3, ['foo', 'bar']);
+
+	m.get({'foo.baz': {bar: true}}, ['foo.baz', 'bar']);
+	m.get({'fo.ob.az': {bar: true}}, ['fo.ob.az', 'bar']);
+});
+
 bench('set', () => {
 	const func = () => 'test';
 	let f1 = {};
@@ -83,6 +126,46 @@ bench('set', () => {
 	m.set(f1, 'foo\\.bar.baz', true);
 
 	m.set(f1, 'fo\\.ob\\.ar.baz', true);
+});
+
+bench('set', () => {
+	const func = () => 'test';
+	let f1 = {};
+
+	m.set(f1, ['foo'], 2);
+
+	f1 = {foo: {bar: 1}};
+	m.set(f1, ['foo', 'bar'], 2);
+
+	m.set(f1, ['foo', 'bar', 'baz'], 3);
+
+	m.set(f1, ['foo', 'bar'], 'test');
+
+	m.set(f1, ['foo', 'bar'], null);
+
+	m.set(f1, ['foo', 'bar'], false);
+
+	m.set(f1, ['foo', 'bar'], undefined);
+
+	m.set(f1, ['foo', 'fake', 'fake2'], 'fake');
+
+	m.set(f1, ['foo', 'function'], func);
+
+	function fn() {}
+	m.set(fn, ['foo', 'bar'], 1);
+
+	f1.fn = fn;
+	m.set(f1, ['fn', 'bar', 'baz'], 2);
+
+	const f2 = {foo: null};
+	m.set(f2, ['foo', 'bar'], 2);
+
+	const f3 = {};
+	m.set(f3, '', 3);
+
+	m.set(f1, ['foo.bar', 'baz'], true);
+
+	m.set(f1, ['fo.ob.ar', 'baz'], true);
 });
 
 bench('delete', () => {
@@ -131,6 +214,52 @@ bench('delete', () => {
 	m.delete(f2, 'dotted.sub.dotted\\.prop');
 });
 
+bench('delete (array)', () => {
+	const func = () => 'test';
+	func.foo = 'bar';
+
+	const inner = {
+		a: 'a',
+		b: 'b',
+		c: 'c',
+		func
+	};
+
+	const f1 = {
+		foo: {
+			bar: {
+				baz: inner
+			}
+		},
+		top: {
+			dog: 'sindre'
+		}
+	};
+
+	m.delete(f1, ['foo', 'bar', 'baz', 'c']);
+
+	m.delete(f1, ['top']);
+
+	m.delete(f1, ['foo', 'bar', 'baz', 'func', 'foo']);
+
+	m.delete(f1, ['foo', 'bar', 'baz', 'func']);
+
+	m.set(f1, ['foo.bar', 'baz'], true);
+	m.delete(f1, ['foo.bar', 'baz']);
+
+	const f2 = {};
+	m.set(f2, ['foo', 'bar.baz'], true);
+	m.delete(f2, ['foo', 'bar.baz']);
+
+	f2.dotted = {
+		sub: {
+			'dotted.prop': 'foo',
+			other: 'prop'
+		}
+	};
+	m.delete(f2, ['dotted', 'sub', 'dotted.prop']);
+});
+
 bench('has', () => {
 	const f1 = {foo: {bar: 1}};
 	m.has(f1);
@@ -151,4 +280,26 @@ bench('has', () => {
 
 	m.has({'foo.baz': {bar: true}}, 'foo\\.baz.bar');
 	m.has({'fo.ob.az': {bar: true}}, 'fo\\.ob\\.az.bar');
+});
+
+bench('has (array)', () => {
+	const f1 = {foo: {bar: 1}};
+	m.has(f1);
+	m.has(f1, ['foo']);
+	m.has({foo: 1}, ['foo']);
+	m.has({foo: null}, ['foo']);
+	m.has({foo: undefined}, ['foo']);
+	m.has({foo: {bar: true}}, ['foo', 'bar']);
+	m.has({foo: {bar: {baz: true}}}, ['foo', 'bar', 'baz']);
+	m.has({foo: {bar: {baz: null}}}, ['foo', 'bar', 'baz']);
+	m.has({foo: {bar: 'a'}}, ['foo', 'fake', 'fake2']);
+
+	function fn() {}
+	fn.foo = {bar: 1};
+	m.has(fn);
+	m.has(fn, ['foo']);
+	m.has(fn, ['foo', 'bar']);
+
+	m.has({'foo.baz': {bar: true}}, ['foo.baz', 'bar']);
+	m.has({'fo.ob.az': {bar: true}}, ['fo.ob.az', 'bar']);
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 'use strict';
 const isObj = require('is-obj');
 
+function isArr(arr) {
+	if (typeof Array.isArray === 'function') {
+		return Array.isArray(arr);
+	}
+
+	return Object.prototype.toString.call(arr) === '[object Array]';
+}
+
 function getPathSegments(path) {
 	const pathArr = path.split('.');
 	const parts = [];
@@ -21,11 +29,13 @@ function getPathSegments(path) {
 
 module.exports = {
 	get(obj, path, value) {
-		if (!isObj(obj) || typeof path !== 'string') {
+		const pathIsArray = isArr(path);
+
+		if (!isObj(obj) || (typeof path !== 'string' && !pathIsArray)) {
 			return obj;
 		}
 
-		const pathArr = getPathSegments(path);
+		const pathArr = (pathIsArray) ? path : getPathSegments(path);
 
 		for (let i = 0; i < pathArr.length; i++) {
 			if (!Object.prototype.propertyIsEnumerable.call(obj, pathArr[i])) {
@@ -52,11 +62,13 @@ module.exports = {
 	},
 
 	set(obj, path, value) {
-		if (!isObj(obj) || typeof path !== 'string') {
+		const pathIsArray = isArr(path);
+
+		if (!isObj(obj) || (typeof path !== 'string' && !pathIsArray)) {
 			return;
 		}
 
-		const pathArr = getPathSegments(path);
+		const pathArr = (pathIsArray) ? path : getPathSegments(path);
 
 		for (let i = 0; i < pathArr.length; i++) {
 			const p = pathArr[i];
@@ -74,11 +86,13 @@ module.exports = {
 	},
 
 	delete(obj, path) {
-		if (!isObj(obj) || typeof path !== 'string') {
+		const pathIsArray = isArr(path);
+
+		if (!isObj(obj) || (typeof path !== 'string' && !pathIsArray)) {
 			return;
 		}
 
-		const pathArr = getPathSegments(path);
+		const pathArr = (pathIsArray) ? path : getPathSegments(path);
 
 		for (let i = 0; i < pathArr.length; i++) {
 			const p = pathArr[i];
@@ -97,11 +111,13 @@ module.exports = {
 	},
 
 	has(obj, path) {
-		if (!isObj(obj) || typeof path !== 'string') {
+		const pathIsArray = isArr(path);
+
+		if (!isObj(obj) || (typeof path !== 'string' && !pathIsArray)) {
 			return false;
 		}
 
-		const pathArr = getPathSegments(path);
+		const pathArr = (pathIsArray) ? path : getPathSegments(path);
 
 		for (let i = 0; i < pathArr.length; i++) {
 			if (isObj(obj)) {

--- a/test.js
+++ b/test.js
@@ -23,6 +23,7 @@ test('get', t => {
 	t.is(m.get({'\\.foo': true}, '\\\\.foo'), true);
 	t.is(m.get({'bar\\.': true}, 'bar\\\\.'), true);
 	t.is(m.get({'foo\\.bar': true}, 'foo\\\\.bar'), true);
+	t.is(m.get({'foo.bar': true}, 'foo\\.bar'), true);
 	t.is(m.get({foo: 1}, 'foo.bar'), undefined);
 
 	const f2 = {};
@@ -38,6 +39,53 @@ test('get', t => {
 	t.is(m.get(fn), fn);
 	t.is(m.get(fn, 'foo'), fn.foo);
 	t.is(m.get(fn, 'foo.bar'), 1);
+
+	const f3 = {foo: null};
+	t.is(m.get(f3, 'foo.bar'), undefined);
+	t.is(m.get(f3, 'foo.bar', 'some value'), 'some value');
+
+	t.is(m.get({'foo.baz': {bar: true}}, 'foo\\.baz.bar'), true);
+	t.is(m.get({'fo.ob.az': {bar: true}}, 'fo\\.ob\\.az.bar'), true);
+});
+
+test('get (array)', t => {
+	const f1 = {foo: {bar: 1}};
+	t.is(m.get(f1), f1);
+	f1[''] = 'foo';
+	t.is(m.get(f1, ['']), 'foo');
+	t.is(m.get(f1, ['foo']), f1.foo);
+	t.is(m.get({foo: 1}, ['foo']), 1);
+	t.is(m.get({foo: null}, ['foo']), null);
+	t.is(m.get({foo: undefined}, ['foo']), undefined);
+	t.is(m.get({foo: {bar: true}}, ['foo', 'bar']), true);
+	t.is(m.get({foo: {bar: {baz: true}}}, ['foo', 'bar', 'baz']), true);
+	t.is(m.get({foo: {bar: {baz: null}}}, ['foo', 'bar', 'baz']), null);
+	t.is(m.get({foo: {bar: 'a'}}, ['foo', 'fake']), undefined);
+	t.is(m.get({foo: {bar: 'a'}}, ['foo', 'fake', 'fake2']), undefined);
+	t.is(m.get({foo: {bar: 'a'}}, ['foo', 'fake', 'fake2'], 'some value'), 'some value');
+	t.is(m.get({'\\': true}, ['\\']), true);
+	t.is(m.get({'\\foo': true}, ['\\foo']), true);
+	t.is(m.get({'bar\\': true}, ['bar\\']), true);
+	t.is(m.get({'foo\\bar': true}, ['foo\\bar']), true);
+	t.is(m.get({'\\.foo': true}, ['\\.foo']), true);
+	t.is(m.get({'bar\\.': true}, ['bar\\.']), true);
+	t.is(m.get({'foo\\.bar': true}, ['foo\\.bar']), true);
+	t.is(m.get({'foo.bar': true}, ['foo.bar']), true);
+	t.is(m.get({foo: 1}, ['foo', 'bar']), undefined);
+
+	const f2 = {};
+	Object.defineProperty(f2, 'foo', {
+		value: 'bar',
+		enumerable: false
+	});
+	t.is(m.get(f2, ['foo']), undefined);
+	t.is(m.get({}, ['hasOwnProperty']), undefined);
+
+	function fn() {}
+	fn.foo = {bar: 1};
+	t.is(m.get(fn), fn);
+	t.is(m.get(fn, ['foo']), fn.foo);
+	t.is(m.get(fn, ['foo', 'bar']), 1);
 
 	const f3 = {foo: null};
 	t.is(m.get(f3, 'foo.bar'), undefined);
@@ -99,6 +147,61 @@ test('set', t => {
 	t.is(f1['foo.bar'].baz, true);
 
 	m.set(f1, 'fo\\.ob\\.ar.baz', true);
+	t.is(f1['fo.ob.ar'].baz, true);
+});
+
+test('set (array)', t => {
+	const func = () => 'test';
+	let f1 = {};
+
+	m.set(f1, ['foo'], 2);
+	t.is(f1.foo, 2);
+
+	f1 = {foo: {bar: 1}};
+	m.set(f1, ['foo', 'bar'], 2);
+	t.is(f1.foo.bar, 2);
+
+	m.set(f1, ['foo', 'bar', 'baz'], 3);
+	t.is(f1.foo.bar.baz, 3);
+
+	m.set(f1, ['foo', 'bar'], 'test');
+	t.is(f1.foo.bar, 'test');
+
+	m.set(f1, ['foo', 'bar'], null);
+	t.is(f1.foo.bar, null);
+
+	m.set(f1, ['foo', 'bar'], false);
+	t.is(f1.foo.bar, false);
+
+	m.set(f1, ['foo', 'bar'], undefined);
+	t.is(f1.foo.bar, undefined);
+
+	m.set(f1, ['foo', 'fake', 'fake2'], 'fake');
+	t.is(f1.foo.fake.fake2, 'fake');
+
+	m.set(f1, ['foo', 'function'], func);
+	t.is(f1.foo.function, func);
+
+	function fn() {}
+	m.set(fn, ['foo', 'bar'], 1);
+	t.is(fn.foo.bar, 1);
+
+	f1.fn = fn;
+	m.set(f1, ['fn', 'bar', 'baz'], 2);
+	t.is(f1.fn.bar.baz, 2);
+
+	const f2 = {foo: null};
+	m.set(f2, ['foo', 'bar'], 2);
+	t.is(f2.foo.bar, 2);
+
+	const f3 = {};
+	m.set(f3, [''], 3);
+	t.is(f3[''], 3);
+
+	m.set(f1, ['foo.bar', 'baz'], true);
+	t.is(f1['foo.bar'].baz, true);
+
+	m.set(f1, ['fo.ob.ar', 'baz'], true);
 	t.is(f1['fo.ob.ar'].baz, true);
 });
 
@@ -165,6 +268,69 @@ test('delete', t => {
 	t.deepEqual(f3, {foo: null});
 });
 
+test('delete (array)', t => {
+	const func = () => 'test';
+	func.foo = 'bar';
+
+	const inner = {
+		a: 'a',
+		b: 'b',
+		c: 'c',
+		func
+	};
+	const f1 = {
+		foo: {
+			bar: {
+				baz: inner
+			}
+		},
+		top: {
+			dog: 'sindre'
+		}
+	};
+
+	t.is(f1.foo.bar.baz.c, 'c');
+	m.delete(f1, ['foo', 'bar', 'baz', 'c']);
+	t.is(f1.foo.bar.baz.c, undefined);
+
+	t.is(f1.top.dog, 'sindre');
+	m.delete(f1, ['top']);
+	t.is(f1.top, undefined);
+
+	t.is(f1.foo.bar.baz.func.foo, 'bar');
+	m.delete(f1, ['foo', 'bar', 'baz', 'func', 'foo']);
+	t.is(f1.foo.bar.baz.func.foo, undefined);
+
+	t.is(f1.foo.bar.baz.func, func);
+	m.delete(f1, ['foo', 'bar', 'baz', 'func']);
+	t.is(f1.foo.bar.baz.func, undefined);
+
+	m.set(f1, ['foo.bar', 'baz'], true);
+	t.is(f1['foo.bar'].baz, true);
+	m.delete(f1, ['foo.bar', 'baz']);
+	t.is(f1['foo.bar'].baz, undefined);
+
+	const f2 = {};
+	m.set(f2, ['foo', 'bar.baz'], true);
+	t.is(f2.foo['bar.baz'], true);
+	m.delete(f2, ['foo', 'bar.baz']);
+	t.is(f2.foo['bar.baz'], undefined);
+
+	f2.dotted = {
+		sub: {
+			'dotted.prop': 'foo',
+			other: 'prop'
+		}
+	};
+	m.delete(f2, ['dotted', 'sub', 'dotted.prop']);
+	t.is(f2.dotted.sub['dotted.prop'], undefined);
+	t.is(f2.dotted.sub.other, 'prop');
+
+	const f3 = {foo: null};
+	m.delete(f3, ['foo', 'bar']);
+	t.deepEqual(f3, {foo: null});
+});
+
 test('has', t => {
 	const f1 = {foo: {bar: 1}};
 	t.is(m.has(f1), false);
@@ -187,4 +353,28 @@ test('has', t => {
 
 	t.is(m.has({'foo.baz': {bar: true}}, 'foo\\.baz.bar'), true);
 	t.is(m.has({'fo.ob.az': {bar: true}}, 'fo\\.ob\\.az.bar'), true);
+});
+
+test('has (array)', t => {
+	const f1 = {foo: {bar: 1}};
+	t.is(m.has(f1), false);
+	t.is(m.has(f1, ['foo']), true);
+	t.is(m.has({foo: 1}, ['foo']), true);
+	t.is(m.has({foo: null}, ['foo']), true);
+	t.is(m.has({foo: undefined}, ['foo']), true);
+	t.is(m.has({foo: {bar: true}}, ['foo', 'bar']), true);
+	t.is(m.has({foo: {bar: {baz: true}}}, ['foo', 'bar', 'baz']), true);
+	t.is(m.has({foo: {bar: {baz: null}}}, ['foo', 'bar', 'baz']), true);
+	t.is(m.has({foo: {bar: 'a'}}, ['foo', 'fake', 'fake2']), false);
+	t.is(m.has({foo: null}, ['foo', 'bar']), false);
+	t.is(m.has({foo: ''}, ['foo', 'bar']), false);
+
+	function fn() {}
+	fn.foo = {bar: 1};
+	t.is(m.has(fn), false);
+	t.is(m.has(fn, ['foo']), true);
+	t.is(m.has(fn, ['foo', 'bar']), true);
+
+	t.is(m.has({'foo.baz': {bar: true}}, ['foo.baz', 'bar']), true);
+	t.is(m.has({'fo.ob.az': {bar: true}}, ['fo.ob.az', 'bar']), true);
 });


### PR DESCRIPTION
This array contains the property path. No need to escape dots anymore.

For instance:

m.get({foo: {bar: {baz: true}}}, ['foo', 'bar', 'baz']) ==> true

I have update test & bench
