### PR TITLE
Return object from the `.set()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,10 @@ module.exports = {
 
 	set(obj, path, value) {
 		if (!isObj(obj) || typeof path !== 'string') {
-			return;
+			return obj;
 		}
 
+		const root = obj;
 		const pathArr = getPathSegments(path);
 
 		for (let i = 0; i < pathArr.length; i++) {
@@ -71,6 +72,8 @@ module.exports = {
 
 			obj = obj[p];
 		}
+
+		return root;
 	},
 
 	delete(obj, path) {

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ dotProp.set(obj, 'foo.bar', 'b');
 console.log(obj);
 //=> {foo: {bar: 'b'}}
 
+const obj2 = dotProp.set(obj, 'foo.bar', 'c');
+console.log(obj2);
+//=> {foo: {bar: 'c'}}
+
 dotProp.set(obj, 'foo.baz', 'x');
 console.log(obj);
 //=> {foo: {bar: 'b', baz: 'x'}}
@@ -59,7 +63,7 @@ console.log(obj);
 
 ### get(obj, path, [defaultValue])
 
-### set(obj, path, value)
+### obj = set(obj, path, value)
 
 ### has(obj, path)
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,8 @@ console.log(obj);
 
 ### get(obj, path, [defaultValue])
 
-### obj = set(obj, path, value)
+### set(obj, path, value)
+Returns the object.
 
 ### has(obj, path)
 

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ dotProp.set(obj, 'foo.bar', 'b');
 console.log(obj);
 //=> {foo: {bar: 'b'}}
 
-const obj2 = dotProp.set(obj, 'foo.bar', 'c');
-console.log(obj2);
+const foo = dotProp.set({}, 'foo.bar', 'c');
+console.log(foo);
 //=> {foo: {bar: 'c'}}
 
 dotProp.set(obj, 'foo.baz', 'x');

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ console.log(obj);
 ### get(obj, path, [defaultValue])
 
 ### set(obj, path, value)
+
 Returns the object.
 
 ### has(obj, path)

--- a/test.js
+++ b/test.js
@@ -56,8 +56,9 @@ test('set', t => {
 	const func = () => 'test';
 	let f1 = {};
 
-	m.set(f1, 'foo', 2);
+	const o1 = m.set(f1, 'foo', 2);
 	t.is(f1.foo, 2);
+	t.is(o1, f1);
 
 	f1 = {foo: {bar: 1}};
 	m.set(f1, 'foo.bar', 2);
@@ -105,6 +106,11 @@ test('set', t => {
 
 	m.set(f1, 'fo\\.ob\\.ar.baz', true);
 	t.is(f1['fo.ob.ar'].baz, true);
+
+	const f4 = 'noobject';
+	const o4 = m.set(f4, 'foo.bar', 2);
+	t.is(f4, 'noobject');
+	t.is(o4, f4);
 });
 
 test('delete', t => {


### PR DESCRIPTION
Just a small change to return the object from the `set` method. I find it convenient in some cases, and it does not add any significant overhead.

Feel free to merge if this makes sense to you. Tests and readme are updated accordingly.