### PR TITLE
make unset an alias of delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function getPathSegments(path) {
 	return parts;
 }
 
-module.exports = {
+const dotProp = {
 	get(obj, path, value) {
 		if (!isObj(obj) || typeof path !== 'string') {
 			return value === undefined ? obj : value;
@@ -121,3 +121,5 @@ module.exports = {
 		return true;
 	}
 };
+
+module.exports = Object.assign(dotProp, {unset: dotProp.delete});

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Returns the object.
 ### has(obj, path)
 
 ### delete(obj, path)
+ - alias: unset(obj, path)
 
 #### obj
 

--- a/test.js
+++ b/test.js
@@ -174,6 +174,8 @@ test('delete', t => {
 	const f3 = {foo: null};
 	m.delete(f3, 'foo.bar');
 	t.deepEqual(f3, {foo: null});
+
+	t.is(m.unset === m.delete, true);
 });
 
 test('has', t => {


### PR DESCRIPTION
``delete`` is a reserved keyword. This adds an alias of ``delete`` to ``unset`` so you can:

```js
import { unset } from 'dot-prop';

const { unset } = require('dot-prop');
```

Instead of
```js
import { delete as unset } from 'dot-prop';

const { delete: unset } = require('dot-prop');
```
[unset](https://lodash.com/docs/4.17.4#unset) api name came from Lodash.
