### PR TITLE
Added empty(obj, path) that also checks for object and arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = {
 
 		return true;
 	},
-	
+
 	empty(obj, path) {
 		if (!isObj(obj) || typeof path !== 'string') {
 			return true;
@@ -143,11 +143,11 @@ module.exports = {
 				break;
 			}
 		}
-		
+
 		if (isObj(obj)) {
-			return Object.keys(obj).length ? false : true;
+			return !Object.keys(obj).length > 0;
 		}
 
-		return obj ? false : true;
+		return !obj;
 	}
 };

--- a/index.js
+++ b/index.js
@@ -119,5 +119,35 @@ module.exports = {
 		}
 
 		return true;
+	},
+	
+	empty(obj, path) {
+		if (!isObj(obj) || typeof path !== 'string') {
+			return true;
+		}
+
+		const pathArr = getPathSegments(path);
+
+		for (let i = 0; i < pathArr.length; i++) {
+			if (!Object.prototype.propertyIsEnumerable.call(obj, pathArr[i])) {
+				return true;
+			}
+
+			obj = obj[pathArr[i]];
+
+			if (obj === undefined || obj === null) {
+				if (i !== pathArr.length - 1) {
+					return true;
+				}
+
+				break;
+			}
+		}
+		
+		if (isObj(obj)) {
+			return Object.keys(obj).length ? false : true;
+		}
+
+		return obj ? false : true;
 	}
 };


### PR DESCRIPTION
Added a simple method for checking whether the value is empty, but it also checks if the value is an object or array and if so checks if it has a .length

This makes for cleaner code:
Instead of:
```
const addOns = dotProp.get(data, 'cart.add_ons');
if( addOns && typeof addOns === 'object' && Object.keys(addOns).length) {
    // ...
}
```
You can now do:
```
if( !dotProp.empty(data, 'cart.add_ons')) {
    // ...
}
```