### PR TITLE
Add array access documentation to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,9 @@ dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep');
 dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep', 'default value');
 //=> 'default value'
 
+dotProp.get({foo: [ {bar: 'a'} ]}, 'foo.0.bar', 'a');
+//=> 'default value'
+
 dotProp.get({foo: {'dot.dot': 'unicorn'}}, 'foo.dot\\.dot');
 //=> 'unicorn'
 


### PR DESCRIPTION
It wasn't obvious to me how to access arrays, so after finding out how to do it, I thought others would benefit from the addition to the README