### PR TITLE
Allow specifying `undefined` as the object for `.get()` and `.has()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,11 +22,11 @@ declare const dotProp: {
 	```
 	*/
 	get<T>(
-		object: {[key: string]: any},
+		object: {[key: string]: any} | undefined,
 		path: string
 	): T | undefined;
 	get<T>(
-		object: {[key: string]: any},
+		object: {[key: string]: any} | undefined,
 		path: string,
 		defaultValue: T
 	): T;
@@ -72,7 +72,7 @@ declare const dotProp: {
 	//=> true
 	```
 	*/
-	has(object: {[key: string]: any}, path: string): boolean;
+	has(object: {[key: string]: any} | undefined, path: string): boolean;
 
 	/**
 	@param object - Object to delete the `path` value.

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,8 @@ Type: `object`
 
 Object to get, set, or delete the `path` value.
 
+You are allowed to pass in `undefined` as the object to the `get` and `has` functions.
+
 #### path
 
 Type: `string`


### PR DESCRIPTION
e.g.

```
> dotProp.get(undefined, 'a')
undefined

> dotProp.get(undefined, 'a', 'b')
'b'
```