### PR TITLE
add array bracket notation support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ const disallowedKeys = new Set([
 const isValidPath = pathSegments => !pathSegments.some(segment => disallowedKeys.has(segment));
 
 function getPathSegments(path) {
+	// Convert brackets in a path string to dot notation.
+	// e.g., 'a.b[3].c' becomes 'a.b.3.c'
+	path = path.replace(/\[(\d+)]/g, '.$1');
+
 	const pathArray = path.split('.');
 	const parts = [];
 

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,9 @@ dotProp.get({foo: {bar: 'a'}}, 'foo.notDefined.deep', 'default value');
 dotProp.get({foo: {'dot.dot': 'unicorn'}}, 'foo.dot\\.dot');
 //=> 'unicorn'
 
+dotProp.get({biz: [ {baz: 'c'}, {baz: 'd'}]}, 'biz[1].baz');
+//=> 'd'
+
 // Setter
 const object = {foo: {bar: 'a'}};
 dotProp.set(object, 'foo.bar', 'b');

--- a/test.js
+++ b/test.js
@@ -55,6 +55,10 @@ test('get', t => {
 	F4Class.prototype.foo = 1;
 	const f4 = new F4Class();
 	t.is(dotProp.get(f4, 'foo'), 1); // #46
+
+	const fixture3 = {a: [{b: 'cool'}]};
+	t.is(dotProp.get(fixture3, 'a[0].b'), 'cool');
+	t.is(dotProp.get(fixture3, 'a[1].b', 'defaultVal'), 'defaultVal');
 });
 
 test('set', t => {

--- a/test.js
+++ b/test.js
@@ -59,6 +59,9 @@ test('get', t => {
 	const fixture3 = {a: [{b: 'cool'}]};
 	t.is(dotProp.get(fixture3, 'a[0].b'), 'cool');
 	t.is(dotProp.get(fixture3, 'a[1].b', 'defaultVal'), 'defaultVal');
+	t.is(dotProp.get(fixture3, 'a[0].nonexistant'), undefined);
+	t.is(dotProp.get(fixture3, 'a[1].nonexistant'), undefined);
+	t.is(dotProp.get(fixture3, 'a[1].nonexistant', 'defaultVal3'), 'defaultVal3');
 });
 
 test('set', t => {


### PR DESCRIPTION
this works now:
```javascript
const obj = { a: [ { b: 'cool' } ]};
const val = dotProp.get(obj, 'a[0].b'); // val === 'cool'
```