### PR TITLE
Fix default value issue when last part of part of path is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
 			}
 		}
 
-		return object;
+		return object === undefined ? value : object;
 	},
 
 	set(object, path, value) {

--- a/test.js
+++ b/test.js
@@ -16,6 +16,7 @@ test('get', t => {
 	t.is(dotProp.get({foo: {bar: 'a'}}, 'foo.fake'), undefined);
 	t.is(dotProp.get({foo: {bar: 'a'}}, 'foo.fake.fake2'), undefined);
 	t.is(dotProp.get({foo: {bar: 'a'}}, 'foo.fake.fake2', 'some value'), 'some value');
+	t.is(dotProp.get({foo: {}}, 'foo.fake', 'some value'), 'some value');
 	t.is(dotProp.get({'\\': true}, '\\'), true);
 	t.is(dotProp.get({'\\foo': true}, '\\foo'), true);
 	t.is(dotProp.get({'bar\\': true}, 'bar\\'), true);


### PR DESCRIPTION
Fix an issue were the default value was not returned if the last part of the path was undefined.