### PR TITLE
Fix crash when modifying array length

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,12 +219,10 @@ export function setProperty(object, path, value) {
 
 		assertNotStringIndex(object, key);
 
-		if (!isObject(object[key])) {
-			object[key] = typeof pathArray[index + 1] === 'number' ? [] : {};
-		}
-
 		if (index === pathArray.length - 1) {
 			object[key] = value;
+		} else if (!isObject(object[key])) {
+			object[key] = typeof pathArray[index + 1] === 'number' ? [] : {};
 		}
 
 		object = object[key];

--- a/test.js
+++ b/test.js
@@ -245,6 +245,11 @@ test('setProperty', t => {
 			bar: true,
 		}],
 	});
+
+	const fixture7 = {foo: ['bar', 'baz']};
+	setProperty(fixture7, 'foo.length', 1);
+	t.is(fixture7.foo.length, 1);
+	t.deepEqual(fixture7, {foo: ['bar']});
 });
 
 test('deleteProperty', t => {


### PR DESCRIPTION
Also avoids unnecessary allocation and set.

Fixes cases like the following:
```javascript
let obj = { a: [1,2] };
dotProp.delete(obj, 'a.1');
dotProp.set(obj, 'a.length', 1);
```
Previously would throw `Uncaught RangeError: Invalid array length` when it tries to set `obj.a.length = {}`