### PR TITLE
Add `escapePath()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,3 +108,26 @@ console.log(object);
 ```
 */
 export function deleteProperty(object: Record<string, any>, path: string): boolean;
+
+/**
+Escape special characters in a path. Useful for sanitizing user input.
+
+@param path The path to sanitize.
+
+@example
+```
+import {getProperty, escapePath} from 'dot-prop';
+
+const object = {
+	foo: {
+		bar: ['👸🏻 You found me Mario!'],
+	},
+	'foo.bar[0]' : '🍄 The princess is in another castle!',
+};
+const escapedPath = escapePath('foo.bar[0]');
+
+console.log(getProperty(object, escapedPath));
+//=> '🍄 The princess is in another castle!'
+```
+*/
+export function escapePath(path: string): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export function deleteProperty(object: Record<string, any>, path: string): boole
 /**
 Escape special characters in a path. Useful for sanitizing user input.
 
-@param path The path to sanitize.
+@param path - The dot path to sanitize.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,11 +120,11 @@ import {getProperty, escapePath} from 'dot-prop';
 
 const object = {
 	foo: {
-		bar: ['👸🏻 You found me Mario!'],
+		bar: '👸🏻 You found me Mario!',
 	},
-	'foo.bar[0]' : '🍄 The princess is in another castle!',
+	'foo.bar' : '🍄 The princess is in another castle!',
 };
-const escapedPath = escapePath('foo.bar[0]');
+const escapedPath = escapePath('foo.bar');
 
 console.log(getProperty(object, escapedPath));
 //=> '🍄 The princess is in another castle!'

--- a/index.js
+++ b/index.js
@@ -281,3 +281,11 @@ export function hasProperty(object, path) {
 
 	return true;
 }
+
+export function escapePath(path) {
+	if (typeof path !== 'string') {
+		throw new TypeError('Expected a string');
+	}
+
+	return path.replace(/[\\.[]/g, '\\$&');
+}

--- a/readme.md
+++ b/readme.md
@@ -61,17 +61,6 @@ object.foo.bar = {x: 'y', y: 'x'};
 deleteProperty(object, 'foo.bar.x');
 console.log(object);
 //=> {foo: {bar: {y: 'x'}}}
-
-const object = {
-	foo: {
-		bar: ['👸🏻 You found me Mario!'],
-	},
-	'foo.bar[0]' : '🍄 The princess is in another castle!',
-};
-const escapedPath = escapePath('foo.bar[0]');
-
-console.log(getProperty(object, escapedPath));
-//=> '🍄 The princess is in another castle!'
 ```
 
 ## API
@@ -103,6 +92,21 @@ Returns a boolean of whether the property existed before being deleted.
 ### escapePath(path)
 
 Escape special characters in a path. Useful for sanitizing user input.
+
+```js
+import {getProperty, escapePath} from 'dot-prop';
+
+const object = {
+	foo: {
+		bar: '👸🏻 You found me Mario!',
+	},
+	'foo.bar' : '🍄 The princess is in another castle!',
+};
+const escapedPath = escapePath('foo.bar');
+
+console.log(getProperty(object, escapedPath));
+//=> '🍄 The princess is in another castle!'
+```
 
 #### object
 

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install dot-prop
 ## Usage
 
 ```js
-import {getProperty, setProperty, hasProperty, deleteProperty, escapePath} from 'dot-prop';
+import {getProperty, setProperty, hasProperty, deleteProperty} from 'dot-prop';
 
 // Getter
 getProperty({foo: {bar: 'unicorn'}}, 'foo.bar');

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install dot-prop
 ## Usage
 
 ```js
-import {getProperty, setProperty, hasProperty, deleteProperty} from 'dot-prop';
+import {getProperty, setProperty, hasProperty, deleteProperty, escapePath} from 'dot-prop';
 
 // Getter
 getProperty({foo: {bar: 'unicorn'}}, 'foo.bar');
@@ -61,6 +61,17 @@ object.foo.bar = {x: 'y', y: 'x'};
 deleteProperty(object, 'foo.bar.x');
 console.log(object);
 //=> {foo: {bar: {y: 'x'}}}
+
+const object = {
+	foo: {
+		bar: ['👸🏻 You found me Mario!'],
+	},
+	'foo.bar[0]' : '🍄 The princess is in another castle!',
+};
+const escapedPath = escapePath('foo.bar[0]');
+
+console.log(getProperty(object, escapedPath));
+//=> '🍄 The princess is in another castle!'
 ```
 
 ## API
@@ -88,6 +99,10 @@ Returns a boolean.
 Delete the property at the given path.
 
 Returns a boolean of whether the property existed before being deleted.
+
+### escapePath(path)
+
+Escape special characters in a path. Useful for sanitizing user input.
 
 #### object
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {getProperty, setProperty, hasProperty, deleteProperty} from './index.js';
+import {getProperty, setProperty, hasProperty, deleteProperty, escapePath} from './index.js';
 
 test('getProperty', t => {
 	const fixture1 = {foo: {bar: 1}};
@@ -381,6 +381,20 @@ test('hasProperty', t => {
 			1: 'bar',
 		}}],
 	}, 'foo[0].bar.1'));
+});
+
+test('escapePath', t => {
+	t.is(escapePath('foo.bar[0]'), 'foo\\.bar\\[0]');
+	t.is(escapePath('foo\\.bar[0]'), 'foo\\\\\\.bar\\[0]');
+	t.is(escapePath('foo\\\\.bar\\\\[0]'), 'foo\\\\\\\\\\.bar\\\\\\\\\\[0]');
+	t.is(escapePath('foo[0].bar'), 'foo\\[0]\\.bar');
+	t.is(escapePath('foo.bar[0].baz'), 'foo\\.bar\\[0]\\.baz');
+	t.is(escapePath('[0].foo'), '\\[0]\\.foo');
+	t.is(escapePath(''), '');
+	t.throws(() => escapePath(0), {
+		instanceOf: TypeError,
+		message: 'Expected a string',
+	});
 });
 
 test('prevent setting/getting `__proto__`', t => {

--- a/test.js
+++ b/test.js
@@ -386,6 +386,8 @@ test('hasProperty', t => {
 test('escapePath', t => {
 	t.is(escapePath('foo.bar[0]'), 'foo\\.bar\\[0]');
 	t.is(escapePath('foo\\.bar[0]'), 'foo\\\\\\.bar\\[0]');
+	t.is(escapePath('foo\\\.bar[0]'), 'foo\\\\\\.bar\\[0]'); // eslint-disable-line no-useless-escape
+	t.is(escapePath('foo\\\\.bar[0]'), 'foo\\\\\\\\\\.bar\\[0]');
 	t.is(escapePath('foo\\\\.bar\\\\[0]'), 'foo\\\\\\\\\\.bar\\\\\\\\\\[0]');
 	t.is(escapePath('foo[0].bar'), 'foo\\[0]\\.bar');
 	t.is(escapePath('foo.bar[0].baz'), 'foo\\.bar\\[0]\\.baz');

--- a/test.js
+++ b/test.js
@@ -391,7 +391,10 @@ test('escapePath', t => {
 	t.is(escapePath('foo.bar[0].baz'), 'foo\\.bar\\[0]\\.baz');
 	t.is(escapePath('[0].foo'), '\\[0]\\.foo');
 	t.is(escapePath(''), '');
-	t.throws(() => escapePath(0), {
+
+	t.throws(() => {
+		escapePath(0);
+	}, {
 		instanceOf: TypeError,
 		message: 'Expected a string',
 	});


### PR DESCRIPTION
```js
import {getProperty, escapePath} from 'dot-prop';

const object = {
	foo: {
		bar: ['👸🏻 You found me Mario!'],
	},
	'foo.bar[0]' : '🍄 The princess is in another castle!',
};
const escapedPath = escapePath('foo.bar[0]');

console.log(getProperty(object, escapedPath));
//=> '🍄 The princess is in another castle!'
```

Fixes #83