### PR TITLE
Switch to expect-type

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,18 +1,18 @@
-import {expectType, expectAssignable} from 'tsd';
+import {expectTypeOf} from 'expect-type';
 import {getProperty, setProperty, hasProperty, deleteProperty} from './index.js';
 
-expectType<string>(getProperty({foo: {bar: 'unicorn'}}, 'foo.bar'));
-expectType<undefined>(getProperty({foo: {bar: 'a'}}, 'foo.notDefined.deep'));
-expectAssignable<string>(
+expectTypeOf(getProperty({foo: {bar: 'unicorn'}}, 'foo.bar')).toBeString();
+expectTypeOf(getProperty({foo: {bar: 'a'}}, 'foo.notDefined.deep')).toBeUndefined();
+expectTypeOf(
 	getProperty({foo: {bar: 'a'}}, 'foo.notDefined.deep', 'default value'),
-);
-expectType<string>(
+).toBeString();
+expectTypeOf(
 	getProperty({foo: {'dot.dot': 'unicorn'}}, 'foo.dot\\.dot'),
-);
+).toEqualTypeOf<string>();
 
 const object = {foo: {bar: 'a'}};
-expectType<typeof object>(setProperty(object, 'foo.bar', 'b'));
+expectTypeOf(setProperty(object, 'foo.bar', 'b')).toEqualTypeOf(object);
 
-expectType<boolean>(hasProperty({foo: {bar: 'unicorn'}}, 'foo.bar'));
+expectTypeOf(hasProperty({foo: {bar: 'unicorn'}}, 'foo.bar')).toEqualTypeOf<boolean>();
 
-expectType<boolean>(deleteProperty({foo: {bar: 'a'}}, 'foo.bar'));
+expectTypeOf(deleteProperty({foo: {bar: 'a'}}, 'foo.bar')).toEqualTypeOf<boolean>();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd",
+		"test": "xo && ava && tsc",
 		"bench": "node benchmark.js"
 	},
 	"files": [
@@ -42,7 +42,8 @@
 	"devDependencies": {
 		"ava": "^4.0.1",
 		"benchmark": "^2.1.4",
-		"tsd": "^0.19.1",
+		"expect-type": "^0.13.0",
+		"typescript": "^4.5.5",
 		"xo": "^0.47.0"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "lib": ["es2020"],
+        "strict": true,
+        "noEmit": true
+    },
+    "include": ["*.ts"]
+}


### PR DESCRIPTION
Fixes #84 

First commit a3b3bad365bb1933ee9700e74e7d61625ae3fb09 adds typescript, a tsconfig.json file and switches to from tsd to expect-type (due to https://github.com/SamVerschueren/tsd/issues/142), to expose the problem in the test-d file.
Second commit will fix the bug in the typings.