### PR TITLE
Improve tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,6 +282,7 @@ export function hasProperty(object, path) {
 	return true;
 }
 
+// TODO: Backslashes with no effect should not be escaped
 export function escapePath(path) {
 	if (typeof path !== 'string') {
 		throw new TypeError('Expected a string');

--- a/test.js
+++ b/test.js
@@ -397,6 +397,9 @@ test('escapePath', t => {
 	t.is(escapePath('foo[0].bar'), 'foo\\[0]\\.bar');
 	t.is(escapePath('foo.bar[0].baz'), 'foo\\.bar\\[0]\\.baz');
 	t.is(escapePath('[0].foo'), '\\[0]\\.foo');
+	t.is(escapePath('\\foo'), '\\\\foo');
+	t.is(escapePath('foo\\'), 'foo\\\\');
+	t.is(escapePath('foo\\\\'), 'foo\\\\\\\\');
 	t.is(escapePath(''), '');
 
 	t.throws(() => {

--- a/test.js
+++ b/test.js
@@ -397,6 +397,7 @@ test('escapePath', t => {
 	t.is(escapePath('foo[0].bar'), 'foo\\[0]\\.bar');
 	t.is(escapePath('foo.bar[0].baz'), 'foo\\.bar\\[0]\\.baz');
 	t.is(escapePath('[0].foo'), '\\[0]\\.foo');
+	// TODO: The following three tests assume that backslashes with no effect are escaped. Update when this changes.
 	t.is(escapePath('\\foo'), '\\\\foo');
 	t.is(escapePath('foo\\'), 'foo\\\\');
 	t.is(escapePath('foo\\\\'), 'foo\\\\\\\\');


### PR DESCRIPTION
Sometimes, slashes work the same way whether they are escaped or not.

1. If a slash is added that doesn't change the behaviour of the proceeding character, the slash is interpreted literally.
2. If a slash escapes another slash, the pair is interpreted as a single slash.

The regex automatically doubles each backslash, transforming the first case into the second case. This has no semantic effect though is less space-efficient, as shown in other tests:

https://github.com/sindresorhus/dot-prop/blob/1794b86f5a8fbb135c6264ddfbc9c4a003c486ab/test.js#L21-L22

A regex lookahead could potentially improve this.