### PR TITLE
Update dependency `type-fest` to `^4.10.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"dotty"
 	],
 	"dependencies": {
-		"type-fest": "^3.8.0"
+		"type-fest": "^4.10.2"
 	},
 	"devDependencies": {
 		"ava": "^5.2.0",


### PR DESCRIPTION
Just to include https://github.com/sindresorhus/type-fest/pull/807 and get rid of error https://github.com/sindresorhus/type-fest/issues/784, short example below.

```
node_modules/type-fest/source/merge-deep.d.ts:140:5 - error TS2321: Excessive stack depth comparing types 'PickRestType<ArrayTail<ArrayTail<Destination>>>[number]' and 'UnknownArrayOrTuple'.

140 > = [
        ~
141  ...DoMergeDeepTupleAndTupleRecursive<OmitRestType<Destination>, OmitRestType<Source>, PickRestTypeFlat<Destination>, PickRestTypeFlat<Source>, Options>,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
142  ...MergeDeepArrayOrTupleElements<PickRestType<Destination>, PickRestType<Source>, Options>,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
143 ];
```