### PR TITLE
Add array filter syntax support

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -161,6 +161,52 @@ suite
 		};
 		deleteProperty(fixture2, String.raw`dotted.sub.dotted\.prop`);
 	})
+	.add('getProperty - with filter', () => {
+		const fixture1 = {
+			users: [
+				{id: 1, name: 'Alice', role: 'admin'},
+				{id: 2, name: 'Bob', role: 'user'},
+				{id: 3, name: 'Charlie', role: 'admin'},
+			],
+		};
+		getProperty(fixture1, 'users[id=1].name');
+		getProperty(fixture1, 'users[role="admin"].name');
+		getProperty(fixture1, 'users[id=2].role');
+		getProperty(fixture1, 'users[id=999].name', 'default');
+		getProperty(fixture1, 'users[role="guest"].name', 'default');
+	})
+	.add('setProperty - with filter', () => {
+		const fixture1 = {
+			users: [
+				{id: 1, name: 'Alice', role: 'admin'},
+				{id: 2, name: 'Bob', role: 'user'},
+			],
+		};
+		setProperty(fixture1, 'users[id=1].name', 'Alicia');
+		setProperty(fixture1, 'users[role="user"].name', 'Robert');
+		setProperty(fixture1, 'users[id=999].name', 'NoMatch');
+	})
+	.add('hasProperty - with filter', () => {
+		const fixture1 = {
+			users: [
+				{id: 1, name: 'Alice', role: 'admin'},
+				{id: 2, name: 'Bob', role: 'user'},
+			],
+		};
+		hasProperty(fixture1, 'users[id=1].name');
+		hasProperty(fixture1, 'users[role="admin"].name');
+		hasProperty(fixture1, 'users[id=999].name');
+	})
+	.add('deleteProperty - with filter', () => {
+		const fixture1 = {
+			users: [
+				{id: 1, name: 'Alice', role: 'admin', temp: 'data'},
+				{id: 2, name: 'Bob', role: 'user', temp: 'data'},
+			],
+		};
+		deleteProperty(fixture1, 'users[id=1].temp');
+		deleteProperty(fixture1, 'users[role="user"].temp');
+	})
 	.on('cycle', event => {
 		console.log(String(event.target));
 	})

--- a/benchmark.js
+++ b/benchmark.js
@@ -200,8 +200,12 @@ suite
 	.add('deleteProperty - with filter', () => {
 		const fixture1 = {
 			users: [
-				{id: 1, name: 'Alice', role: 'admin', temp: 'data'},
-				{id: 2, name: 'Bob', role: 'user', temp: 'data'},
+				{
+					id: 1, name: 'Alice', role: 'admin', temp: 'data',
+				},
+				{
+					id: 2, name: 'Bob', role: 'user', temp: 'data',
+				},
 			],
 		};
 		deleteProperty(fixture1, 'users[id=1].temp');

--- a/index.js
+++ b/index.js
@@ -266,7 +266,6 @@ export function parsePath(path) { // eslint-disable-line complexity
 			}
 
 			default: {
-
 				if (currentPart === 'indexEnd') {
 					throw new Error(`Invalid character '${character}' after an index at position ${position}`);
 				}
@@ -446,7 +445,9 @@ export function setProperty(object, path, value) {
 			object = found;
 		} else if (index === pathArray.length - 1) {
 			object[key] = value;
-		} else if (!isObject(object[key])) {
+		} else if (isObject(object[key])) {
+			object = object[key];
+		} else {
 			const nextKey = pathArray[index + 1];
 
 			// If next key is a filter, check if we would need to create an array that won't have matches
@@ -458,8 +459,6 @@ export function setProperty(object, path, value) {
 			// Create arrays for numeric indices, objects for string keys
 			const shouldCreateArray = typeof nextKey === 'number';
 			object[key] = shouldCreateArray ? [] : {};
-			object = object[key];
-		} else {
 			object = object[key];
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -2086,7 +2086,7 @@ test('array filter syntax - array path usage', t => {
 	const filterPath = ['items', {key: 'id', value: 1}, 'name'];
 	t.is(getProperty(object, filterPath), 'first');
 
-	// setProperty only updates existing items, doesn't create
+	// `setProperty` only updates existing items, doesn't create
 	const object2 = {items: [{id: 1, name: 'old'}]};
 	setProperty(object2, filterPath, 'test');
 	t.is(object2.items[0].name, 'test');


### PR DESCRIPTION
I understand that this is an edge-case and I can imagine that you would not want to add support for this, however I am sharing since we needed this code for our use-case. We can use this from our fork, but if this is helpful for others then you're free to use it here.

This adds support for a new syntax for accessing specific array properties for arrays of objects, by filtering on a specific item property e.g. `foo[key="value"]` to access the first array item where `item.key === value`.

- only JSON primitive types (string, number, boolean, null)
- setProperty only updates existing items, doesn't create new ones